### PR TITLE
Add process_model as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "process_model"]
+	path = process_model
+	url = https://github.com/Cambridge-ICCS/process_model.git


### PR DESCRIPTION
Re-add the `process_model` code as a submodule to this repo.  This should include the necessary tests that take an example model, run `process_model` on it, and then compile the resulting output, linking it against this library.